### PR TITLE
Generar xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 dist
 package-lock.json
 node_modules
-src/generated
+test/input
 .idea
 .vscode
 *.log

--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ Para probar getToken
 ```
 ts-node --require dotenv/config test/getToken.ts
 ```
+
+Para probar getXML
+```
+ts-node --require dotenv/config test/genXML.ts
+```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Para probar las funcionalidades se recomienda crear un .env en donde se especifi
 USERNAME_TEST=
 PASSWORD_TEST=
 IS_STG=
-SOURCE_URI=
+SOURCE_JSON_URI=
 ```
 
 Para probar getToken

--- a/src/lib/genXML/index.ts
+++ b/src/lib/genXML/index.ts
@@ -1,9 +1,14 @@
-import { FacturaElectronica } from '../facturaInterfaces'
 import { j2xParser } from 'fast-xml-parser'
+import { XML_ATTRS, declaration } from './xmlConfig'
 
-const defaultOptions = {}
+const defaultOptions = {
+  attrNodeName: 'attr'
+}
 
-export default (facturaElectronica: FacturaElectronica): any => {
+export default (obj: object): any => {
   const parser = new j2xParser(defaultOptions) // eslint-disable-line new-cap
-  return parser.parse(facturaElectronica)
+  const mainKey = Object.keys(obj)[0]
+  console.log('mainKey', mainKey)
+  obj[mainKey].attr = XML_ATTRS
+  return declaration + parser.parse(obj)
 }

--- a/src/lib/genXML/index.ts
+++ b/src/lib/genXML/index.ts
@@ -1,0 +1,9 @@
+import { FacturaElectronica } from '../facturaInterfaces'
+import { j2xParser } from 'fast-xml-parser'
+
+const defaultOptions = {}
+
+export default (facturaElectronica: FacturaElectronica): any => {
+  const parser = new j2xParser(defaultOptions) // eslint-disable-line new-cap
+  return parser.parse(facturaElectronica)
+}

--- a/src/lib/genXML/index.ts
+++ b/src/lib/genXML/index.ts
@@ -1,14 +1,9 @@
 import { j2xParser } from 'fast-xml-parser'
-import { XML_ATTRS, declaration } from './xmlConfig'
-
-const defaultOptions = {
-  attrNodeName: 'attr'
-}
+import { XML_ATTRS, declaration, defaultOptions } from './xmlConfig'
 
 export default (obj: object): any => {
   const parser = new j2xParser(defaultOptions) // eslint-disable-line new-cap
   const mainKey = Object.keys(obj)[0]
-  console.log('mainKey', mainKey)
   obj[mainKey].attr = XML_ATTRS
   return declaration + parser.parse(obj)
 }

--- a/src/lib/genXML/xmlConfig.ts
+++ b/src/lib/genXML/xmlConfig.ts
@@ -1,10 +1,12 @@
 const XML_SCHEMA_NS = 'https://cdn.comprobanteselectronicos.go.cr/xml-schemas/v4.3/facturaElectronica'
 const XML_SCHEMA_XSI = 'https://www.hacienda.go.cr/ATV/ComprobanteElectronico/docs/esquemas/2016/v4.3/FacturaElectronica_V4.3.xsd'
 
+export const declaration = '<?xml version="1.0" encoding="utf-8"?>'
+
 export const XML_ATTRS = {
-  '@_xmlns': XML_SCHEMA_NS,
-  '@_xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#',
-  '@_xmlns:xsd': 'http://www.w3.org/2001/XMLSchema',
-  '@_xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-  '@_xsi:schemaLocation': `${XML_SCHEMA_NS}${XML_SCHEMA_XSI}`
+  xmlns: XML_SCHEMA_NS,
+  'xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#',
+  'xmlns:xsd': 'http://www.w3.org/2001/XMLSchema',
+  'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+  'xsi:schemaLocation': `${XML_SCHEMA_NS}${XML_SCHEMA_XSI}`
 }

--- a/src/lib/genXML/xmlConfig.ts
+++ b/src/lib/genXML/xmlConfig.ts
@@ -3,6 +3,10 @@ const XML_SCHEMA_XSI = 'https://www.hacienda.go.cr/ATV/ComprobanteElectronico/do
 
 export const declaration = '<?xml version="1.0" encoding="utf-8"?>'
 
+export const defaultOptions = {
+  attrNodeName: 'attr'
+}
+
 export const XML_ATTRS = {
   xmlns: XML_SCHEMA_NS,
   'xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#',

--- a/test/genXML.ts
+++ b/test/genXML.ts
@@ -1,0 +1,9 @@
+import fs from 'fs'
+import genXML from '../src/lib/genXML'
+const SOURCE_JSON_URI = process.env.SOURCE_JSON_URI
+const jsonInput = fs.readFileSync(SOURCE_JSON_URI)
+const parsedObject = JSON.parse(jsonInput.toString())
+
+const XML = genXML(parsedObject)
+
+console.log('XML', XML)


### PR DESCRIPTION
Este código genera el un XML valido con los atributos necesarios de los comprobantes electrónicos (xmlns, xmlns:ds, xmlns:xsd , xmlns:xsi, xsi:schemaLocation). 
Para probarlo se debe:
1.  Ingresar un JSON de la factura electronica. test/input/factura-ejemplo.json
2. Establecer ruta de archivo en var de ambiente SOURCE_JSON_URI=
3. Ejecutar ts-node --require dotenv/config test/genXML.ts

Este código excluye la funcionalidad de completar campos que no se hayan establecido en el entrada, esta funcionalidad está pendiente.
